### PR TITLE
Enforce splitting before arithmetic operator

### DIFF
--- a/{{cookiecutter.project_dir}}/.style.yapf
+++ b/{{cookiecutter.project_dir}}/.style.yapf
@@ -15,6 +15,7 @@ split_complex_comprehension = true
 split_before_dict_set_generator = true
 split_before_logical_operator = true
 split_before_bitwise_operator = true
+split_before_arithmetic_operator = true
 coalesce_brackets = true
 
 each_dict_entry_on_separate_line = true


### PR DESCRIPTION
Make YAPF line breaking around arithmetic operators consistent with [PEP8](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator) (and flake8 config).